### PR TITLE
Create jwt cookie filter to add token to cookie

### DIFF
--- a/src/main/java/com/test/permissionusesjwt/configuration/JwtCookieFilter.java
+++ b/src/main/java/com/test/permissionusesjwt/configuration/JwtCookieFilter.java
@@ -1,0 +1,48 @@
+package com.test.permissionusesjwt.configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtCookieFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("jwt".equals(cookie.getName())) {
+                    token = cookie.getValue();
+                    break;
+                }
+            }
+        }
+        if (token != null) {
+            // Chuyển token từ cookie thành Authorization header
+            String finalToken = token;
+            HttpServletRequestWrapper requestWrapper = new HttpServletRequestWrapper(request) {
+                @Override
+                public String getHeader(String name) {
+                    if ("Authorization".equalsIgnoreCase(name)) {
+                        return "Bearer " + finalToken;
+                    }
+                    return super.getHeader(name);
+                }
+            };
+            filterChain.doFilter(requestWrapper, response);
+        } else {
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/com/test/permissionusesjwt/configuration/SecurityConfig.java
+++ b/src/main/java/com/test/permissionusesjwt/configuration/SecurityConfig.java
@@ -1,10 +1,7 @@
 package com.test.permissionusesjwt.configuration;
 
-import com.nimbusds.jose.jwk.SecretJWK;
-//import com.test.permissionusesjwt.enums.Role;
-import com.test.permissionusesjwt.entity.Role;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,18 +12,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
-import javax.crypto.spec.SecretKeySpec;
 
 @Configuration
 @EnableWebSecurity
@@ -55,7 +48,7 @@ public class SecurityConfig {
                         .permitAll()
                         .anyRequest()
                         .authenticated());
-
+        httpSecurity.addFilterBefore(new JwtCookieFilter(), UsernamePasswordAuthenticationFilter.class);
         httpSecurity.oauth2ResourceServer(oauth2->
                 oauth2.jwt(jwtConfigurer -> jwtConfigurer.decoder(customJwtDecoder)
                         .jwtAuthenticationConverter(jwtAuthenticationConverter()))

--- a/src/main/java/com/test/permissionusesjwt/controller/AuthenticationController.java
+++ b/src/main/java/com/test/permissionusesjwt/controller/AuthenticationController.java
@@ -5,6 +5,8 @@ import com.test.permissionusesjwt.dto.request.*;
 import com.test.permissionusesjwt.dto.response.AuthenticationResponse;
 import com.test.permissionusesjwt.dto.response.IntrospectResponse;
 import com.test.permissionusesjwt.service.AuthenticationService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -24,11 +26,18 @@ public class AuthenticationController {
     AuthenticationService authenticationService;
 
     @PostMapping("/log-in")
-    ApiResponse<AuthenticationResponse> authenticate (@RequestBody AuthenticationRequest request)
+    ApiResponse<String> authenticate (@RequestBody AuthenticationRequest request,
+        HttpServletResponse response)
     {
-        var result  =  authenticationService.authenticate(request);
-        return ApiResponse.<AuthenticationResponse>builder()
-                .result(result)
+        AuthenticationResponse authResponse =  authenticationService.authenticate(request);
+        Cookie cookie = new Cookie("jwt", authResponse.getToken());
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); //dùng cho https
+        cookie.setPath("/");
+        cookie.setMaxAge(3600);
+        response.addCookie(cookie);
+        return ApiResponse.<String>builder()
+                .result("Login successfully")
                 .build();
     }
 


### PR DESCRIPTION
To be more clearly, I have some issue with token based authentication. Before I saved token in Local Storage, I had aware of danger inside it. So, i changed my solution by saving token in cookie and automagically setting cookie with http-only in headers. 
First, I added jwt to cookies in AuthenticationController.Java 
Second, i wrote a new filter which was a JwtCookieFiltter and transform Cookie to Authorization header in order to auto-configuration. 
Third, i added it (JwtCookieFillter) to SecurityFilterChain  in order to run first oauth2.0 Authorization bearer token. (3) 
Why I do this (3)? -> because I want to keep stateless in jwt and share token with Third Party Authentication. So i can use cookies in client and share token with Third Party Authentication